### PR TITLE
Align footer with header horizontal spacing

### DIFF
--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -27,9 +27,7 @@ interface Props {
 }
 
 const FooterContainer = styled.div`
-  margin: 0 auto;
-  max-width: 1300px;
-  padding: 20px ${contentMargin.md};
+  padding: 20px ${contentMargin.sm};
 
   ${applyMediaQueryMd(css`
     padding: 0 ${contentMargin.md};
@@ -143,7 +141,7 @@ const Footer: FC<Props> = ({ footerMenu, siteMap }) => {
 
   return (
     <FooterContainer>
-      <Container>
+      <Container fluid>
         <Row>
           <Col noGutter xs={12}>
             <Divider />


### PR DESCRIPTION
This PR brings the horizontal spacing closer to the designs and to the header's spacing.

Due to some alignments within `react-awesome-styled-grid` it's still a few pixels off.